### PR TITLE
Remove const to prevent from compiler from failing.

### DIFF
--- a/hdtSMP64/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
+++ b/hdtSMP64/hdtSkinnedMesh/hdtSkinnedMeshAlgorithm.cpp
@@ -8,7 +8,7 @@ namespace hdt
 	{
 	}
 
-	static const CollisionResult zero;
+	static CollisionResult zero;
 
 	template <class T0, class T1>
 	struct CollisionCheck


### PR DESCRIPTION
const object must be initialized or the compiler will fail.
Tested in game, no problem found so far.
I'm a noob on developing Windows project, so if I made a mistake, please correct me. Trying to learn more. :)